### PR TITLE
feat: burn(uint256)

### DIFF
--- a/src/UsdPlus.sol
+++ b/src/UsdPlus.sol
@@ -9,7 +9,7 @@ import {
 import {AccessControlDefaultAdminRulesUpgradeable} from
     "openzeppelin-contracts-upgradeable/contracts/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
 import {ITransferRestrictor} from "./ITransferRestrictor.sol";
-import {ERC7281Min} from "./ERC7281/ERC7281Min.sol";
+import {ERC7281Min, IERC7281Min} from "./ERC7281/ERC7281Min.sol";
 
 /// @notice stablecoin
 /// @author Dinari (https://github.com/dinaricrypto/usdplus-contracts/blob/main/src/UsdPlus.sol)
@@ -118,21 +118,28 @@ contract UsdPlus is UUPSUpgradeable, ERC20PermitUpgradeable, ERC7281Min, AccessC
         _setIssuerLimits(issuer, mintingLimit, burningLimit);
     }
 
-    // ------------------ Minting/Burning (ERC-7281) ------------------
+    // ------------------ Minting/Burning ------------------
 
-    /// @notice mint USD+ to account
+    /// @inheritdoc IERC7281Min
     function mint(address to, uint256 value) external {
         _useMintingLimits(_msgSender(), value);
         _mint(to, value);
     }
 
-    /// @notice burn USD+ from msg.sender
+    /// @inheritdoc IERC7281Min
     function burn(address from, uint256 value) external {
         address spender = _msgSender();
         if (from != spender) {
             _spendAllowance(from, spender, value);
         }
         _useBurningLimits(spender, value);
+        _burn(from, value);
+    }
+
+    /// @notice burn USD+ from msg.sender
+    function burn(uint256 value) external {
+        address from = _msgSender();
+        _useBurningLimits(from, value);
         _burn(from, value);
     }
 

--- a/test/USDPlus.t.sol
+++ b/test/USDPlus.t.sol
@@ -113,6 +113,28 @@ contract UsdPlusTest is Test {
         assertEq(usdplus.burningCurrentLimitOf(BURNER), type(uint256).max);
     }
 
+    function test_burn2(uint256 amount) public {
+        vm.assume(amount > 0);
+
+        // mint USD+ to user for testing
+        vm.prank(MINTER);
+        usdplus.mint(BURNER, amount);
+
+        // non-burner cannot burn
+        vm.expectRevert(IERC7281Min.ERC7281_LimitExceeded.selector);
+        vm.prank(USER);
+        usdplus.burn(amount);
+
+        // burner can burn
+        vm.prank(BURNER);
+        usdplus.burn(amount);
+        assertEq(usdplus.balanceOf(BURNER), 0);
+        assertEq(usdplus.mintingMaxLimitOf(BURNER), 0);
+        assertEq(usdplus.burningMaxLimitOf(BURNER), type(uint256).max);
+        assertEq(usdplus.mintingCurrentLimitOf(BURNER), 0);
+        assertEq(usdplus.burningCurrentLimitOf(BURNER), type(uint256).max);
+    }
+
     function test_burnFrom(uint256 amount) public {
         vm.assume(amount > 0);
 


### PR DESCRIPTION
This is a compatibility update for Chainlink CCIP. They use `.burn(uint256)` for their automated mint/burn deployments. In general, it burns from the sender and is redundant with our existing call, equivalent to `.burn(msg.sender, amount)`