### PR TITLE
[DSHARE-220] Deterministic contract deployments

### DIFF
--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -63,58 +63,72 @@ contract DeployAll is Script {
 
         /// ------------------ usd+ ------------------
 
-        TransferRestrictor transferRestrictor = TransferRestrictor(deployWithCreate2(salt, implBytecodes.transferRestrictorBytecode));
+        TransferRestrictor transferRestrictor =
+            TransferRestrictor(deployWithCreate2(salt, implBytecodes.transferRestrictorBytecode));
 
         UsdPlus usdplusImpl = UsdPlus(deployWithCreate2(salt, implBytecodes.usdplusImplBytecode));
 
-        UsdPlus usdplus = UsdPlus(deployWithCreate2(
-            salt,
-            abi.encodePacked(
-                type(ERC1967Proxy).creationCode,
-                abi.encode(
-                    address(usdplusImpl), abi.encodeCall(UsdPlus.initialize, (cfg.treasury, transferRestrictor, cfg.owner))
+        UsdPlus usdplus = UsdPlus(
+            deployWithCreate2(
+                salt,
+                abi.encodePacked(
+                    type(ERC1967Proxy).creationCode,
+                    abi.encode(
+                        address(usdplusImpl),
+                        abi.encodeCall(UsdPlus.initialize, (cfg.treasury, transferRestrictor, cfg.owner))
+                    )
                 )
             )
-        ));
+        );
 
-        WrappedUsdPlus wrappedusdplusImpl = WrappedUsdPlus(deployWithCreate2(salt, implBytecodes.wrappedusdplusImplBytecode));
+        WrappedUsdPlus wrappedusdplusImpl =
+            WrappedUsdPlus(deployWithCreate2(salt, implBytecodes.wrappedusdplusImplBytecode));
 
-        WrappedUsdPlus wrappedusdplus = WrappedUsdPlus(deployWithCreate2(
-            salt,
-            abi.encodePacked(
-                type(ERC1967Proxy).creationCode,
-                abi.encode(
-                    address(wrappedusdplusImpl), abi.encodeCall(WrappedUsdPlus.initialize, (address(usdplus), cfg.owner))
+        WrappedUsdPlus wrappedusdplus = WrappedUsdPlus(
+            deployWithCreate2(
+                salt,
+                abi.encodePacked(
+                    type(ERC1967Proxy).creationCode,
+                    abi.encode(
+                        address(wrappedusdplusImpl),
+                        abi.encodeCall(WrappedUsdPlus.initialize, (address(usdplus), cfg.owner))
+                    )
                 )
             )
-        ));
+        );
 
         /// ------------------ usd+ minter/redeemer ------------------
 
         UsdPlusMinter minterImpl = UsdPlusMinter(deployWithCreate2(salt, implBytecodes.minterImplBytecode));
 
-        UsdPlusMinter minter = UsdPlusMinter(deployWithCreate2(
-            salt,
-            abi.encodePacked(
-                type(ERC1967Proxy).creationCode,
-                abi.encode(
-                    address(minterImpl),
-                    abi.encodeCall(UsdPlusMinter.initialize, (address(usdplus), cfg.treasury, cfg.owner))
+        UsdPlusMinter minter = UsdPlusMinter(
+            deployWithCreate2(
+                salt,
+                abi.encodePacked(
+                    type(ERC1967Proxy).creationCode,
+                    abi.encode(
+                        address(minterImpl),
+                        abi.encodeCall(UsdPlusMinter.initialize, (address(usdplus), cfg.treasury, cfg.owner))
+                    )
                 )
             )
-        ));
+        );
         usdplus.setIssuerLimits(address(minter), type(uint256).max, 0);
         minter.setPaymentTokenOracle(cfg.usdc, cfg.paymentTokenOracle);
 
         UsdPlusRedeemer redeemerImpl = UsdPlusRedeemer(deployWithCreate2(salt, implBytecodes.redeemerImplBytecode));
 
-        UsdPlusRedeemer redeemer = UsdPlusRedeemer(deployWithCreate2(
-            salt,
-            abi.encodePacked(
-                type(ERC1967Proxy).creationCode,
-                abi.encode(address(redeemerImpl), abi.encodeCall(UsdPlusRedeemer.initialize, (address(usdplus), cfg.owner)))
+        UsdPlusRedeemer redeemer = UsdPlusRedeemer(
+            deployWithCreate2(
+                salt,
+                abi.encodePacked(
+                    type(ERC1967Proxy).creationCode,
+                    abi.encode(
+                        address(redeemerImpl), abi.encodeCall(UsdPlusRedeemer.initialize, (address(usdplus), cfg.owner))
+                    )
+                )
             )
-        ));
+        );
         usdplus.setIssuerLimits(address(redeemer), 0, type(uint256).max);
         redeemer.grantRole(redeemer.FULFILLER_ROLE(), cfg.treasury);
         redeemer.setPaymentTokenOracle(cfg.usdc, cfg.paymentTokenOracle);

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -14,7 +14,7 @@ import {ERC1967Proxy} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC19
 
 contract DeployAll is Script {
     error ContractDeploymentFailed();
-    
+
     struct DeployConfig {
         address owner;
         address treasury;
@@ -47,10 +47,8 @@ contract DeployAll is Script {
 
         /// ------------------ usd+ ------------------
 
-        bytes memory transferRestrictorBytecode = abi.encodePacked(
-            type(TransferRestrictor).creationCode,
-            abi.encode(cfg.owner)
-        );
+        bytes memory transferRestrictorBytecode =
+            abi.encodePacked(type(TransferRestrictor).creationCode, abi.encode(cfg.owner));
 
         TransferRestrictor transferRestrictor = TransferRestrictor(deployWithCreate2(salt, transferRestrictorBytecode));
 
@@ -60,8 +58,7 @@ contract DeployAll is Script {
         bytes memory usdplusProxyBytecode = abi.encodePacked(
             type(ERC1967Proxy).creationCode,
             abi.encode(
-                address(usdplusImpl),
-                abi.encodeCall(UsdPlus.initialize, (cfg.treasury, transferRestrictor, cfg.owner))
+                address(usdplusImpl), abi.encodeCall(UsdPlus.initialize, (cfg.treasury, transferRestrictor, cfg.owner))
             )
         );
         UsdPlus usdplus = UsdPlus(deployWithCreate2(salt, usdplusProxyBytecode));
@@ -72,8 +69,7 @@ contract DeployAll is Script {
         bytes memory wrappedusdplusProxyBytecode = abi.encodePacked(
             type(ERC1967Proxy).creationCode,
             abi.encode(
-                address(wrappedusdplusImpl),
-                abi.encodeCall(WrappedUsdPlus.initialize, (address(usdplus), cfg.owner))
+                address(wrappedusdplusImpl), abi.encodeCall(WrappedUsdPlus.initialize, (address(usdplus), cfg.owner))
             )
         );
         WrappedUsdPlus wrappedusdplus = WrappedUsdPlus(deployWithCreate2(salt, wrappedusdplusProxyBytecode));
@@ -99,9 +95,7 @@ contract DeployAll is Script {
 
         bytes memory redeemerProxyBytecode = abi.encodePacked(
             type(ERC1967Proxy).creationCode,
-            abi.encode(
-                address(redeemerImpl), abi.encodeCall(UsdPlusRedeemer.initialize, (address(usdplus), cfg.owner))
-            )
+            abi.encode(address(redeemerImpl), abi.encodeCall(UsdPlusRedeemer.initialize, (address(usdplus), cfg.owner)))
         );
         UsdPlusRedeemer redeemer = UsdPlusRedeemer(deployWithCreate2(salt, redeemerProxyBytecode));
         usdplus.setIssuerLimits(address(redeemer), 0, type(uint256).max);
@@ -111,10 +105,9 @@ contract DeployAll is Script {
         vm.stopBroadcast();
     }
 
-
     function deployWithCreate2(bytes32 salt, bytes memory bytecode) internal returns (address addr) {
         assembly {
-            addr:= create2(0, add(bytecode, 0x20), mload(bytecode), salt)
+            addr := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
         }
         if (addr == address(0)) revert ContractDeploymentFailed();
     }

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -42,14 +42,6 @@ contract DeployAll is Script {
             paymentTokenOracle: AggregatorV3Interface(vm.envAddress("USDCORACLE"))
         });
 
-        ImplementationBytecodes memory implBytecodes = ImplementationBytecodes({
-            transferRestrictorBytecode: abi.encodePacked(type(TransferRestrictor).creationCode, abi.encode(cfg.owner)),
-            usdplusImplBytecode: type(UsdPlus).creationCode,
-            wrappedusdplusImplBytecode: type(WrappedUsdPlus).creationCode,
-            minterImplBytecode: type(UsdPlusMinter).creationCode,
-            redeemerImplBytecode: type(UsdPlusRedeemer).creationCode
-        });
-
         console.log("deployer: %s", deployer);
 
         // Send txs as deployer

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -20,14 +20,6 @@ contract DeployAll is Script {
         AggregatorV3Interface paymentTokenOracle;
     }
 
-    struct ImplementationBytecodes {
-        bytes transferRestrictorBytecode;
-        bytes usdplusImplBytecode;
-        bytes wrappedusdplusImplBytecode;
-        bytes minterImplBytecode;
-        bytes redeemerImplBytecode;
-    }
-
     function run() external {
         // Load env variables
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_KEY");


### PR DESCRIPTION
This PR updates the DeployAll script to use the CREATE2 opcode for deploying both implementation and proxy contracts. By using CREATE2, we ensure that contract addresses remain consistent across different EVM chains, provided the same seed (salt) and deployer address are used.