### PR TITLE
feat: selfpermit and multicall for arbitrary redemption receiver support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/kinto-contracts-helpers"]
 	path = lib/kinto-contracts-helpers
 	url = https://github.com/dinaricrypto/kinto-contracts-helpers
+[submodule "lib/multicall"]
+	path = lib/multicall
+	url = https://github.com/mds1/multicall

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "lib/kinto-contracts-helpers"]
 	path = lib/kinto-contracts-helpers
 	url = https://github.com/dinaricrypto/kinto-contracts-helpers
-[submodule "lib/multicall"]
-	path = lib/multicall
-	url = https://github.com/mds1/multicall

--- a/script/RedeemMulticall.s.sol
+++ b/script/RedeemMulticall.s.sol
@@ -10,17 +10,13 @@ contract RedeemMulticall is Script {
     // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     bytes32 public constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
 
-    function getPermitStructHash(IUsdPlusRedeemer.Permit memory _permit) internal pure returns (bytes32) {
+    function getPermitStructHash(Permit memory _permit) internal pure returns (bytes32) {
         return keccak256(
             abi.encode(PERMIT_TYPEHASH, _permit.owner, _permit.spender, _permit.value, _permit.nonce, _permit.deadline)
         );
     }
 
-    function getPermitTypedDataHash(bytes32 domainSeparator, IUsdPlusRedeemer.Permit memory _permit)
-        public
-        pure
-        returns (bytes32)
-    {
+    function getPermitTypedDataHash(bytes32 domainSeparator, Permit memory _permit) public pure returns (bytes32) {
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, getPermitStructHash(_permit)));
     }
 
@@ -41,7 +37,7 @@ contract RedeemMulticall is Script {
         // User sign USD+ permit
         vm.startBroadcast(userPrivateKey);
 
-        IUsdPlusRedeemer.Permit memory permit = IUsdPlusRedeemer.Permit({
+        Permit memory permit = Permit({
             owner: user,
             spender: address(redeemer),
             value: amount,

--- a/script/RedeemMulticall.s.sol
+++ b/script/RedeemMulticall.s.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import "forge-std/Script.sol";
+import {ERC20Permit} from "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import {UsdPlus} from "../src/UsdPlus.sol";
+import {UsdPlusRedeemer} from "../src/UsdPlusRedeemer.sol";
+
+contract RedeemMulticall is Script {
+    struct Permit {
+        address owner;
+        address spender;
+        uint256 value;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+
+    function getPermitStructHash(Permit memory _permit) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(PERMIT_TYPEHASH, _permit.owner, _permit.spender, _permit.value, _permit.nonce, _permit.deadline)
+        );
+    }
+
+    function getPermitTypedDataHash(bytes32 domainSeparator, Permit memory _permit) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, getPermitStructHash(_permit)));
+    }
+
+    function run() external {
+        uint256 userPrivateKey = vm.envUint("USER_KEY");
+        uint256 operatorPrivateKey = vm.envUint("OPERATOR_KEY");
+        ERC20Permit usdc = ERC20Permit(vm.envAddress("USDC"));
+        UsdPlus usdplus = UsdPlus(vm.envAddress("USDPLUS"));
+        UsdPlusRedeemer redeemer = UsdPlusRedeemer(vm.envAddress("USDPLUS_REDEEMER"));
+
+        uint256 amount = 10_000_000; // 10 USD+
+        address user = vm.addr(userPrivateKey);
+        address operator = vm.addr(operatorPrivateKey);
+
+        console.log("user: %s", user);
+        console.log("operator: %s", operator);
+        console.log("USD+ amount: %d", amount);
+
+        // User sign USD+ permit
+        vm.startBroadcast(userPrivateKey);
+
+        Permit memory permit = Permit({
+            owner: user,
+            spender: operator,
+            value: amount,
+            nonce: usdplus.nonces(user),
+            deadline: block.timestamp + 30 minutes
+        });
+
+        bytes32 digest = getPermitTypedDataHash(usdplus.DOMAIN_SEPARATOR(), permit);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPrivateKey, digest);
+
+        vm.stopBroadcast();
+
+        // Operator pull USD+ and request redeem USD+ to USDC
+        vm.startBroadcast(operatorPrivateKey);
+
+        // Pull from user
+        // usdc.permit(permit.owner, permit.spender, permit.value, permit.deadline, v, r, s);
+        // usdc.transferFrom(permit.owner, operator, permit.value);
+
+        // // Deposit to USD+
+        // usdc.approve(address(minter), permit.value);
+        // uint256 usdplusAmount = minter.deposit(usdc, permit.value, operator);
+        // console.log("USD+ amount: %d", usdplusAmount);
+
+        // // Transfer USD+ to user
+        // usdplus.transfer(user, usdplusAmount);
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/kinto/ConfigAll.s.sol
+++ b/script/kinto/ConfigAll.s.sol
@@ -99,15 +99,6 @@ contract ConfigAll is Script, EntryPointHelper {
         _grantRole(address(cfg.minter), cfg.minter.PRIVATE_MINTER_ROLE(), cfg.operator2, owner, deployerPrivateKey);
         console.log("PRIVATE_MINTER_ROLE granted");
 
-        // Grant PRIVATE_REDEEMER_ROLE to operators
-        // permissions to call
-        // - privateRequestRedeem(IERC20 paymentToken, Permit calldata permit, bytes calldata signature)
-        _grantRole(address(cfg.redeemer), cfg.redeemer.PRIVATE_REDEEMER_ROLE(), cfg.operator, owner, deployerPrivateKey);
-        _grantRole(
-            address(cfg.redeemer), cfg.redeemer.PRIVATE_REDEEMER_ROLE(), cfg.operator2, owner, deployerPrivateKey
-        );
-        console.log("PRIVATE_REDEEMER_ROLE granted");
-
         // Grant FULFILLER_ROLE to operators
         // permissions to call
         // - fulfill(uint256 ticket)

--- a/script/redeemmulticall.sh
+++ b/script/redeemmulticall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cp .env-arbitrum-sepolia .env
+source .env
+
+forge script script/RedeemMulticall.s.sol:RedeemMulticall --rpc-url $RPC_URL -vvv

--- a/src/IUsdPlusMinter.sol
+++ b/src/IUsdPlusMinter.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.23;
 
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {AggregatorV3Interface} from "chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {Permit} from "./SelfPermit.sol";
 
 interface IUsdPlusMinter {
     event PaymentRecipientSet(address indexed paymentRecipient);
@@ -12,14 +13,6 @@ interface IUsdPlusMinter {
     );
 
     error PaymentTokenNotAccepted();
-
-    struct Permit {
-        address owner;
-        address spender;
-        uint256 value;
-        uint256 nonce;
-        uint256 deadline;
-    }
 
     /// @notice USD+
     function usdplus() external view returns (address);

--- a/src/IUsdPlusRedeemer.sol
+++ b/src/IUsdPlusRedeemer.sol
@@ -33,14 +33,6 @@ interface IUsdPlusRedeemer {
     error PaymentTokenNotAccepted();
     error InvalidTicket();
 
-    struct Permit {
-        address owner;
-        address spender;
-        uint256 value;
-        uint256 nonce;
-        uint256 deadline;
-    }
-
     /// @notice USD+
     function usdplus() external view returns (address);
 

--- a/src/SelfPermit.sol
+++ b/src/SelfPermit.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.23;
+
+import {MulticallUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/utils/MulticallUpgradeable.sol";
+import {IERC20Permit} from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
+
+struct Permit {
+    address owner;
+    address spender;
+    uint256 value;
+    uint256 nonce;
+    uint256 deadline;
+}
+
+/// @notice Allows contract to call permit before other methods in the same transaction
+/// @author Dinari (https://github.com/dinaricrypto/usdplus-contracts/blob/main/src/Redeemer.sol)
+abstract contract SelfPermit is MulticallUpgradeable {
+    /// @notice Split a signature into `v`, `r`, `s` components
+    /// @param sig The signature
+    /// @param v secp256k1 signature from the holder along with `r` and `s`
+    /// @param r signature from the holder along with `v` and `s`
+    /// @param s signature from the holder along with `r` and `v`
+    function splitSignature(bytes memory sig) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
+        assembly {
+            r := mload(add(sig, 0x20))
+            s := mload(add(sig, 0x40))
+            v := byte(0, mload(add(sig, 0x60)))
+        }
+    }
+
+    /// @notice Permits this contract to spend a given token from `msg.sender`
+    /// @dev The `spender` is always address(this).
+    /// @param token The address of the token spent
+    /// @param permit The permit data
+    /// @param signature The signature of the owner
+    function selfPermit(address token, Permit calldata permit, bytes calldata signature) public {
+        (uint8 v, bytes32 r, bytes32 s) = splitSignature(signature);
+        IERC20Permit(token).permit(permit.owner, address(this), permit.value, permit.deadline, v, r, s);
+    }
+}

--- a/src/UsdPlusMinter.sol
+++ b/src/UsdPlusMinter.sol
@@ -9,13 +9,14 @@ import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/Safe
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {AggregatorV3Interface} from "chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import {IERC20Permit} from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
-import {IERC20Permit} from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
+
 import {IUsdPlusMinter} from "./IUsdPlusMinter.sol";
 import {UsdPlus} from "./UsdPlus.sol";
+import {SelfPermit, Permit} from "./SelfPermit.sol";
 
 /// @notice USD+ minter
 /// @author Dinari (https://github.com/dinaricrypto/usdplus-contracts/blob/main/src/Minter.sol)
-contract UsdPlusMinter is IUsdPlusMinter, UUPSUpgradeable, AccessControlDefaultAdminRulesUpgradeable {
+contract UsdPlusMinter is IUsdPlusMinter, UUPSUpgradeable, AccessControlDefaultAdminRulesUpgradeable, SelfPermit {
     /// ------------------ Types ------------------
     using SafeERC20 for IERC20;
 
@@ -104,21 +105,6 @@ contract UsdPlusMinter is IUsdPlusMinter, UUPSUpgradeable, AccessControlDefaultA
         UsdPlusMinterStorage storage $ = _getUsdPlusMinterStorage();
         $._paymentTokenOracle[paymentToken] = oracle;
         emit PaymentTokenOracleSet(paymentToken, oracle);
-    }
-
-    /// ------------------ Permit ------------------
-
-    /// @notice Split a signature into `v`, `r`, `s` components
-    /// @param sig The signature
-    /// @param v secp256k1 signature from the holder along with `r` and `s`
-    /// @param r signature from the holder along with `v` and `s`
-    /// @param s signature from the holder along with `r` and `v`
-    function splitSignature(bytes memory sig) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
-        assembly {
-            r := mload(add(sig, 0x20))
-            s := mload(add(sig, 0x40))
-            v := byte(0, mload(add(sig, 0x60)))
-        }
     }
 
     // ------------------ Mint ------------------

--- a/test/USDPlus.t.sol
+++ b/test/USDPlus.t.sol
@@ -205,6 +205,8 @@ contract UsdPlusTest is Test {
     function test_rebaseAdd(uint128 initialAmount, uint128 rebaseAmount) public {
         vm.assume(initialAmount > 1);
         vm.assume(rebaseAmount > 0);
+        // TODO: add this check within method and revert
+        vm.assume(rebaseAmount < initialAmount);
 
         // mint USD+
         address user2 = address(0x123b);

--- a/test/UsdPlusMinter.t.sol
+++ b/test/UsdPlusMinter.t.sol
@@ -209,7 +209,7 @@ contract UsdPlusMinterTest is Test {
         assertEq(usdplus.balanceOf(USER), 0);
         uint256 balanceBefore = paymentToken.balanceOf(USER);
 
-        IUsdPlusMinter.Permit memory permit = IUsdPlusMinter.Permit({
+        Permit memory permit = Permit({
             owner: sigPermit.owner,
             spender: sigPermit.spender,
             value: sigPermit.value,


### PR DESCRIPTION
This allows atomic permit execution and redemption request support without implementing custom methods. 

1:1 exchange rate in following PR.