### PR TITLE
[DSHARE-885] Add caller validation in UsdPlusRedeemer.requestRedeem

### DIFF
--- a/src/IUsdPlusRedeemer.sol
+++ b/src/IUsdPlusRedeemer.sol
@@ -34,6 +34,7 @@ interface IUsdPlusRedeemer {
 
     error PaymentTokenNotAccepted();
     error InvalidTicket();
+    error UnauthorizedRedeemer();
 
     /// @notice USD+
     function usdplus() external view returns (address);

--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -159,6 +159,10 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, UUPSUpgradeable, AccessControlDefa
             ticket = $._nextTicket++;
         }
 
+        if (owner != address(this) && msg.sender != owner) {
+            revert UnauthorizedRedeemer();
+        }
+
         $._requests[ticket] = Request({
             owner: owner == address(this) ? msg.sender : owner,
             receiver: receiver,

--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import {UUPSUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {AccessControlDefaultAdminRulesUpgradeable} from
     "openzeppelin-contracts-upgradeable/contracts/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
+import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
@@ -15,7 +16,13 @@ import {SelfPermit} from "./SelfPermit.sol";
 
 /// @notice manages requests for USD+ burning
 /// @author Dinari (https://github.com/dinaricrypto/usdplus-contracts/blob/main/src/Redeemer.sol)
-contract UsdPlusRedeemer is IUsdPlusRedeemer, UUPSUpgradeable, AccessControlDefaultAdminRulesUpgradeable, SelfPermit {
+contract UsdPlusRedeemer is
+    IUsdPlusRedeemer,
+    UUPSUpgradeable,
+    AccessControlDefaultAdminRulesUpgradeable,
+    SelfPermit,
+    PausableUpgradeable
+{
     /// ------------------ Types ------------------
     using SafeERC20 for IERC20;
 
@@ -51,6 +58,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, UUPSUpgradeable, AccessControlDefa
 
     function initialize(address usdPlus, address initialOwner) public initializer {
         __AccessControlDefaultAdminRules_init_unchained(0, initialOwner);
+        __Pausable_init();
 
         UsdPlusRedeemerStorage storage $ = _getUsdPlusRedeemerStorage();
         $._usdplus = usdPlus;
@@ -104,6 +112,16 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, UUPSUpgradeable, AccessControlDefa
         emit PaymentTokenOracleSet(payment, oracle);
     }
 
+    /// @notice pause contract
+    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    /// @notice unpause contract
+    function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
     // ----------------- Requests -----------------
 
     /// @inheritdoc IUsdPlusRedeemer
@@ -128,6 +146,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, UUPSUpgradeable, AccessControlDefa
     /// @inheritdoc IUsdPlusRedeemer
     function requestWithdraw(IERC20 paymentToken, uint256 paymentTokenAmount, address receiver, address owner)
         public
+        whenNotPaused
         returns (uint256 ticket)
     {
         if (receiver == address(0)) revert ZeroAddress();
@@ -159,7 +178,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, UUPSUpgradeable, AccessControlDefa
             ticket = $._nextTicket++;
         }
 
-        if (owner != address(this) && msg.sender != owner) {
+        if (msg.sender != owner) {
             revert UnauthorizedRedeemer();
         }
 
@@ -190,6 +209,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, UUPSUpgradeable, AccessControlDefa
     /// @inheritdoc IUsdPlusRedeemer
     function requestRedeem(IERC20 paymentToken, uint256 usdplusAmount, address receiver, address owner)
         public
+        whenNotPaused
         returns (uint256 ticket)
     {
         if (receiver == address(0)) revert ZeroAddress();

--- a/test/UsdPlusRedeemer.t.sol
+++ b/test/UsdPlusRedeemer.t.sol
@@ -176,6 +176,33 @@ contract UsdPlusRedeemerTest is Test {
         redeemer.requestRedeem(paymentToken, 0, USER, USER);
     }
 
+    function test_pause_unpause() public {
+        // non-admin cannot pause
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), redeemer.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        redeemer.pause();
+
+        // admin can pause
+        vm.prank(ADMIN);
+        redeemer.pause();
+        assertEq(redeemer.paused(), true);
+
+        // non-admin cannot unpause
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), redeemer.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        redeemer.unpause();
+
+        vm.prank(ADMIN);
+        redeemer.unpause();
+        assertEq(redeemer.paused(), false);
+    }
+
     function test_requestRedeem(uint256 amount) public {
         vm.assume(amount > 0 && amount < type(uint256).max / 2);
 

--- a/test/UsdPlusRedeemer.t.sol
+++ b/test/UsdPlusRedeemer.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import {UsdPlus} from "../src/UsdPlus.sol";
 import {TransferRestrictor} from "../src/TransferRestrictor.sol";
 import "../src/UsdPlusRedeemer.sol";
+import {IUsdPlusRedeemer} from "../src/IUsdPlusRedeemer.sol";
 import {Permit} from "../src/SelfPermit.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {SigUtils} from "./utils/SigUtils.sol";
@@ -204,6 +205,13 @@ contract UsdPlusRedeemerTest is Test {
         vm.prank(ADMIN);
         usdplus.setIssuerLimits(address(redeemer), 0, type(uint256).max);
 
+        // Test unauthorized redeemer scenario
+        address ATTACKER = address(0xdead);
+        vm.prank(ATTACKER);
+        vm.expectRevert(IUsdPlusRedeemer.UnauthorizedRedeemer.selector);
+        redeemer.requestRedeem(paymentToken, amount, USER, USER);
+
+        // Test successful case
         vm.expectEmit(true, true, true, true);
         emit RequestCreated(0, USER, paymentToken, redemptionEstimate, amount);
         vm.prank(USER);
@@ -214,6 +222,23 @@ contract UsdPlusRedeemerTest is Test {
 
         IUsdPlusRedeemer.Request memory request = redeemer.requests(ticket);
         assertEq(request.paymentTokenAmount, redemptionEstimate);
+    }
+
+    // Add a separate test for unauthorized redemption
+    function test_requestRedeem_UnauthorizedRedeemer() public {
+        uint256 amount = 1000e6; // 1000 USDC
+        address ATTACKER = address(0xdead);
+
+        vm.prank(ADMIN);
+        redeemer.setPaymentTokenOracle(paymentToken, AggregatorV3Interface(usdcPriceOracle));
+
+        vm.prank(USER);
+        usdplus.approve(address(redeemer), amount);
+
+        // Try to redeem on behalf of USER without authorization
+        vm.prank(ATTACKER);
+        vm.expectRevert(IUsdPlusRedeemer.UnauthorizedRedeemer.selector);
+        redeemer.requestRedeem(paymentToken, amount, USER, USER);
     }
 
     function test_permitRequestRedeem(uint256 amount) public {
@@ -248,18 +273,28 @@ contract UsdPlusRedeemerTest is Test {
         );
         calls[1] = abi.encodeCall(redeemer.requestRedeem, (paymentToken, amount, USER, USER));
 
+        // Test invalid signature reverts
+        vm.prank(USER);
         vm.expectRevert();
         redeemer.multicall(calls);
 
+        // Test unauthorized caller reverts
         calls[0] = abi.encodeCall(
             redeemer.selfPermit, (address(usdplus), permit.owner, permit.value, permit.deadline, v, r, s)
         );
         vm.prank(ADMIN);
+        vm.expectRevert(IUsdPlusRedeemer.UnauthorizedRedeemer.selector);
+        redeemer.multicall(calls);
+
+        // Test successful case with proper owner
+        vm.prank(USER);
         bytes[] memory results = redeemer.multicall(calls);
         uint256 ticket = abi.decode(results[1], (uint256));
 
         IUsdPlusRedeemer.Request memory request = redeemer.requests(ticket);
-        // assertEq(request.paymentTokenAmount, permit.value);
+        assertEq(request.owner, USER);
+        uint256 expectedPaymentAmount = redeemer.previewRedeem(paymentToken, amount);
+        assertEq(request.paymentTokenAmount, expectedPaymentAmount);
     }
 
     function test_fulfillInvalidTicketReverts(uint256 ticket) public {


### PR DESCRIPTION
[https://dinari.atlassian.net/jira/software/projects/DSHARE/boards/2?assignee=712020%3Aa20e54a0-5e4c-4203-9d5b-a3911c614d59&selectedIssue=DSHARE-885](https://dinari.atlassian.net/jira/software/projects/DSHARE/boards/2?assignee=712020%3Aa20e54a0-5e4c-4203-9d5b-a3911c614d59&selectedIssue=DSHARE-885)

Problem: There is a potential vulnerability in the requestRedeem function of the USD+ redeemer smart contract, indicated by an unauthorized redemption request.
Impact: Unknown
Causes: The vulnerability arose because the smart contract does not verify if the msg.sender has the right to create redemption on behalf of the owner before executing safeTransfer.