### PR TITLE
feat: explicitly transfer from msg.sender

### DIFF
--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -16,6 +16,7 @@ import {SelfPermit} from "./SelfPermit.sol";
 
 /// @notice manages requests for USD+ burning
 /// @author Dinari (https://github.com/dinaricrypto/usdplus-contracts/blob/main/src/Redeemer.sol)
+// TODO: remove owner from redeem request calls
 contract UsdPlusRedeemer is
     IUsdPlusRedeemer,
     UUPSUpgradeable,
@@ -183,7 +184,7 @@ contract UsdPlusRedeemer is
         }
 
         $._requests[ticket] = Request({
-            owner: owner,
+            owner: msg.sender,
             receiver: receiver,
             paymentToken: paymentToken,
             paymentTokenAmount: paymentTokenAmount,
@@ -192,10 +193,7 @@ contract UsdPlusRedeemer is
 
         emit RequestCreated(ticket, receiver, paymentToken, paymentTokenAmount, usdplusAmount);
 
-        if (owner != address(this)) {
-            // slither-disable-next-line arbitrary-send-erc20
-            IERC20($._usdplus).safeTransferFrom(owner, address(this), usdplusAmount);
-        }
+        IERC20($._usdplus).safeTransferFrom(msg.sender, address(this), usdplusAmount);
 
         UsdPlus($._usdplus).burn(address(this), usdplusAmount);
     }


### PR DESCRIPTION
Stronger guarantee here. We can make the interface change to remove `owner` altogether in a later PR.