### PR TITLE
feat: controlled upgradeable initializable version enforcement

### DIFF
--- a/src/TransferRestrictor.sol
+++ b/src/TransferRestrictor.sol
@@ -40,13 +40,13 @@ contract TransferRestrictor is ControlledUpgradeable, ITransferRestrictor {
 
     /// ------------------ Version ------------------ ///
 
-    function version() public pure returns (uint8) {
+    function version() public pure override returns (uint8) {
         return 1;
     }
 
     /// ------------------ Initialization ------------------ ///
 
-    function initialize(address initialOwner, address upgrader) public initializer {
+    function initialize(address initialOwner, address upgrader) public reinitializer(version()) {
         __ControlledUpgradeable_init(initialOwner, upgrader);
         _grantRole(RESTRICTOR_ROLE, initialOwner);
     }

--- a/src/UsdPlus.sol
+++ b/src/UsdPlus.sol
@@ -47,14 +47,14 @@ contract UsdPlus is ControlledUpgradeable, ERC20Rebasing, ERC7281Min {
         ITransferRestrictor initialTransferRestrictor,
         address initialOwner,
         address upgrader
-    ) public initializer {
+    ) public reinitializer(version()) {
         __ControlledUpgradeable_init(initialOwner, upgrader);
         UsdPlusStorage storage $ = _getUsdPlusStorage();
         $._treasury = initialTreasury;
         $._transferRestrictor = initialTransferRestrictor;
     }
 
-    function reinitialize(address upgrader) public reinitializer(2) {
+    function reinitialize(address upgrader) public reinitializer(version()) {
         grantRole(UPGRADER_ROLE, upgrader);
     }
 
@@ -75,7 +75,7 @@ contract UsdPlus is ControlledUpgradeable, ERC20Rebasing, ERC7281Min {
         return "USD+";
     }
 
-    function version() public pure returns (uint8) {
+    function version() public pure override returns (uint8) {
         return 1;
     }
 

--- a/src/UsdPlusMinter.sol
+++ b/src/UsdPlusMinter.sol
@@ -50,7 +50,7 @@ contract UsdPlusMinter is IUsdPlusMinter, ControlledUpgradeable, SelfPermit {
 
     function initialize(address usdPlus, address initialPaymentRecipient, address initialOwner, address upgrader)
         public
-        initializer
+        reinitializer(version())
     {
         __ControlledUpgradeable_init(initialOwner, upgrader);
         UsdPlusMinterStorage storage $ = _getUsdPlusMinterStorage();
@@ -58,7 +58,7 @@ contract UsdPlusMinter is IUsdPlusMinter, ControlledUpgradeable, SelfPermit {
         $._paymentRecipient = initialPaymentRecipient;
     }
 
-    function reinitialize(address upgrader) public reinitializer(2) {
+    function reinitialize(address upgrader) public reinitializer(version()) {
         grantRole(UPGRADER_ROLE, upgrader);
     }
 
@@ -87,7 +87,7 @@ contract UsdPlusMinter is IUsdPlusMinter, ControlledUpgradeable, SelfPermit {
         return $._paymentTokenOracle[paymentToken];
     }
 
-    function version() public pure returns (uint8) {
+    function version() public pure override returns (uint8) {
         return 1;
     }
 

--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -49,7 +49,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, ControlledUpgradeable, SelfPermit,
 
     /// ------------------ Initialization ------------------
 
-    function initialize(address usdPlus, address initialOwner, address upgrader) public initializer {
+    function initialize(address usdPlus, address initialOwner, address upgrader) public reinitializer(version()) {
         __ControlledUpgradeable_init(initialOwner, upgrader);
         __Pausable_init();
 
@@ -58,7 +58,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, ControlledUpgradeable, SelfPermit,
         $._nextTicket = 0;
     }
 
-    function reinitialize(address upgrader, string memory newVersion) public reinitializer(2) {
+    function reinitialize(address upgrader, string memory newVersion) public reinitializer(version()) {
         grantRole(UPGRADER_ROLE, upgrader);
     }
 
@@ -93,7 +93,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, ControlledUpgradeable, SelfPermit,
         return $._nextTicket;
     }
 
-    function version() public pure returns (uint8) {
+    function version() public pure override returns (uint8) {
         return 1;
     }
 

--- a/src/WrappedUsdPlus.sol
+++ b/src/WrappedUsdPlus.sol
@@ -19,7 +19,7 @@ import {ControlledUpgradeable} from "./deployment/ControlledUpgradeable.sol";
 contract WrappedUsdPlus is UUPSUpgradeable, ERC4626Upgradeable, ERC20PermitUpgradeable, ControlledUpgradeable {
     /// ------------------ Initialization ------------------
 
-    function initialize(address usdplus, address initialOwner, address upgrader) public initializer {
+    function initialize(address usdplus, address initialOwner, address upgrader) public reinitializer(version()) {
         __ERC4626_init(IERC20(usdplus));
         __ERC20Permit_init("wUSD+");
         __ERC20_init("wUSD+", "wUSD+");
@@ -37,7 +37,7 @@ contract WrappedUsdPlus is UUPSUpgradeable, ERC4626Upgradeable, ERC20PermitUpgra
         return ERC4626Upgradeable.decimals();
     }
 
-    function version() public pure returns (uint8) {
+    function version() public pure override returns (uint8) {
         return 1;
     }
 

--- a/src/bridge/CCIPWaypoint.sol
+++ b/src/bridge/CCIPWaypoint.sol
@@ -79,7 +79,10 @@ contract CCIPWaypoint is Initializable, ControlledUpgradeable, PausableUpgradeab
 
     /// ------------------ Initialization ------------------
 
-    function initialize(address usdPlus, address router, address initialOwner, address upgrader) public initializer {
+    function initialize(address usdPlus, address router, address initialOwner, address upgrader)
+        public
+        reinitializer(version())
+    {
         __CCIPReceiver_init(router);
         __ControlledUpgradeable_init(initialOwner, upgrader);
         __Pausable_init();
@@ -88,7 +91,7 @@ contract CCIPWaypoint is Initializable, ControlledUpgradeable, PausableUpgradeab
         $._usdplus = usdPlus;
     }
 
-    function reinitialize(address initialOwner, address upgrader) external reinitializer(2) {
+    function reinitialize(address initialOwner, address upgrader) external reinitializer(version()) {
         __ControlledUpgradeable_init(initialOwner, upgrader);
     }
 
@@ -119,7 +122,7 @@ contract CCIPWaypoint is Initializable, ControlledUpgradeable, PausableUpgradeab
         );
     }
 
-    function version() public pure returns (uint8) {
+    function version() public pure override returns (uint8) {
         return 1;
     }
 

--- a/src/deployment/ControlledUpgradeable.sol
+++ b/src/deployment/ControlledUpgradeable.sol
@@ -19,4 +19,6 @@ abstract contract ControlledUpgradeable is UUPSUpgradeable, AccessControlDefault
         __AccessControlDefaultAdminRules_init_unchained(0, initialOwner);
         _grantRole(UPGRADER_ROLE, upgrader);
     }
+
+    function version() public virtual returns (uint8);
 }

--- a/test/UsdPlusRedeemer.t.sol
+++ b/test/UsdPlusRedeemer.t.sol
@@ -280,7 +280,7 @@ contract UsdPlusRedeemerTest is Test {
     }
 
     function test_permitRequestRedeem(uint256 amount) public {
-        vm.assume(amount > 0 && amount < type(uint256).max / 2);
+        vm.assume(amount > 1 && amount < type(uint256).max / 2);
 
         vm.startPrank(ADMIN);
         redeemer.setPaymentTokenOracle(paymentToken, AggregatorV3Interface(usdcPriceOracle));
@@ -431,7 +431,7 @@ contract UsdPlusRedeemerTest is Test {
     }
 
     function test_burnRequest(uint256 amount) public {
-        vm.assume(amount > 0 && amount < type(uint256).max / 2);
+        vm.assume(amount > 1 && amount < type(uint256).max / 2);
 
         vm.startPrank(ADMIN);
         redeemer.setPaymentTokenOracle(paymentToken, AggregatorV3Interface(usdcPriceOracle));

--- a/test/deployment/ControlledUpgrade.t.sol
+++ b/test/deployment/ControlledUpgrade.t.sol
@@ -53,7 +53,7 @@ contract ControlledUpgradeableTest is Test {
         //check if the upgrade is successful
         assertEq(upgradeableContract.hasRole(controlledImpl.UPGRADER_ROLE(), UPGRADER), true);
         assertEq(upgradeableContract.hasRole(upgradeableContract.DEFAULT_ADMIN_ROLE(), ADMIN), true);
-        assertEq(MockControlled(address(upgradeableContract)).version(), 1);
+        assertEq(MockControlled(address(upgradeableContract)).version(), 2);
 
         //upgrade with upgrader
         vm.expectRevert(
@@ -72,7 +72,7 @@ contract ControlledUpgradeableTest is Test {
         upgradeableContract.upgradeToAndCall(
             address(controlledV2Impl), abi.encodeWithSelector(MockControlledV2.reinitialize.selector, 0)
         );
-        assertEq(MockControlled(address(upgradeableContract)).version(), 2);
+        assertEq(MockControlled(address(upgradeableContract)).version(), 3);
         vm.stopPrank();
     }
 
@@ -89,7 +89,7 @@ contract ControlledUpgradeableTest is Test {
             MockOwnableControlled(address(ownable)).hasRole(ownableControlledImpl.DEFAULT_ADMIN_ROLE(), ADMIN), true
         );
         assertEq(MockOwnableControlled(address(ownable)).hasRole(ownableControlledImpl.UPGRADER_ROLE(), UPGRADER), true);
-        assertEq(MockOwnableControlled(address(ownable)).version(), 1);
+        assertEq(MockOwnableControlled(address(ownable)).version(), 2);
 
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/utils/mocks/MockControlled.sol
+++ b/test/utils/mocks/MockControlled.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.23;
 import {ControlledUpgradeable} from "../../../src/deployment/ControlledUpgradeable.sol";
 
 contract MockControlled is ControlledUpgradeable {
-    function initialize(address initialOwner) public initializer {
-        __AccessControlDefaultAdminRules_init_unchained(0, initialOwner);
+    function initialize(address initialOwner) public reinitializer(version()) {
+        __ControlledUpgradeable_init(initialOwner, initialOwner);
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -13,11 +13,11 @@ contract MockControlled is ControlledUpgradeable {
         _disableInitializers();
     }
 
-    function reinitialize(address upgrader) external reinitializer(2) {
+    function reinitialize(address upgrader) external reinitializer(version()) {
         _grantRole(UPGRADER_ROLE, upgrader);
     }
 
-    function version() public pure returns (int256) {
-        return 1;
+    function version() public pure override returns (uint8) {
+        return 2;
     }
 }

--- a/test/utils/mocks/MockControlledV2.sol
+++ b/test/utils/mocks/MockControlledV2.sol
@@ -6,9 +6,8 @@ import {ControlledUpgradeable} from "../../../src/deployment/ControlledUpgradeab
 contract MockControlledV2 is ControlledUpgradeable {
     uint256 public value;
 
-    function initialize(address initialOwner, address upgrader) public initializer {
-        __AccessControlDefaultAdminRules_init_unchained(0, initialOwner);
-        _grantRole(UPGRADER_ROLE, upgrader);
+    function initialize(address initialOwner, address upgrader) public reinitializer(version()) {
+        __ControlledUpgradeable_init(initialOwner, upgrader);
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -16,11 +15,11 @@ contract MockControlledV2 is ControlledUpgradeable {
         _disableInitializers();
     }
 
-    function reinitialize(uint256 _value) external reinitializer(3) {
+    function reinitialize(uint256 _value) external reinitializer(version()) {
         value = _value;
     }
 
-    function version() public pure returns (int256) {
-        return 2;
+    function version() public pure override returns (uint8) {
+        return 3;
     }
 }

--- a/test/utils/mocks/MockOwnableControlled.sol
+++ b/test/utils/mocks/MockOwnableControlled.sol
@@ -6,7 +6,7 @@ import {ControlledUpgradeable} from "../../../src/deployment/ControlledUpgradeab
 contract MockOwnableControlled is ControlledUpgradeable {
     uint256 private _value;
 
-    function initialize(address initialOwner) public initializer {
+    function initialize(address initialOwner) public reinitializer(version()) {
         __AccessControlDefaultAdminRules_init_unchained(0, initialOwner);
     }
 
@@ -15,11 +15,11 @@ contract MockOwnableControlled is ControlledUpgradeable {
         _disableInitializers();
     }
 
-    function reinitialize(address initialOwner, address upgrader) external reinitializer(2) {
+    function reinitialize(address initialOwner, address upgrader) external reinitializer(version()) {
         __ControlledUpgradeable_init(initialOwner, upgrader);
     }
 
-    function version() public pure returns (int256) {
-        return 1;
+    function version() public pure override returns (uint8) {
+        return 2;
     }
 }


### PR DESCRIPTION
Defines a virtual method in ControlledUpgradeable for `version()`.

Passes that `version()` to `reinitializer(version())` for all (re)initialization calls to enforce consistent upgrade safety checks and prevent reinitialization vulnerabilities.