### PR TITLE
[DSHARE-1067] Update ControlledUpgradeable with public version method

### DIFF
--- a/src/TransferRestrictor.sol
+++ b/src/TransferRestrictor.sol
@@ -44,6 +44,10 @@ contract TransferRestrictor is ControlledUpgradeable, ITransferRestrictor {
         return 1;
     }
 
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.0";
+    }
+
     /// ------------------ Initialization ------------------ ///
 
     function initialize(address initialOwner, address upgrader) public reinitializer(version()) {

--- a/src/UsdPlus.sol
+++ b/src/UsdPlus.sol
@@ -79,6 +79,10 @@ contract UsdPlus is ControlledUpgradeable, ERC20Rebasing, ERC7281Min {
         return 1;
     }
 
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.0";
+    }
+
     /// @notice treasury for digital assets backing USD+
     function treasury() public view returns (address) {
         UsdPlusStorage storage $ = _getUsdPlusStorage();

--- a/src/UsdPlusMinter.sol
+++ b/src/UsdPlusMinter.sol
@@ -91,6 +91,10 @@ contract UsdPlusMinter is IUsdPlusMinter, ControlledUpgradeable, SelfPermit {
         return 1;
     }
 
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.0";
+    }
+
     /// ------------------ Admin ------------------
 
     /// @notice set payment recipient

--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -58,7 +58,7 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, ControlledUpgradeable, SelfPermit,
         $._nextTicket = 0;
     }
 
-    function reinitialize(address upgrader, string memory newVersion) public reinitializer(version()) {
+    function reinitialize(address upgrader) public reinitializer(version()) {
         grantRole(UPGRADER_ROLE, upgrader);
     }
 
@@ -95,6 +95,10 @@ contract UsdPlusRedeemer is IUsdPlusRedeemer, ControlledUpgradeable, SelfPermit,
 
     function version() public pure override returns (uint8) {
         return 1;
+    }
+
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.0";
     }
 
     /// ------------------ Admin ------------------

--- a/src/WrappedUsdPlus.sol
+++ b/src/WrappedUsdPlus.sol
@@ -41,6 +41,10 @@ contract WrappedUsdPlus is UUPSUpgradeable, ERC4626Upgradeable, ERC20PermitUpgra
         return 1;
     }
 
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.0";
+    }
+
     function isBlacklisted(address account) external view returns (bool) {
         return UsdPlus(asset()).isBlacklisted(account);
     }

--- a/src/bridge/CCIPWaypoint.sol
+++ b/src/bridge/CCIPWaypoint.sol
@@ -126,6 +126,10 @@ contract CCIPWaypoint is Initializable, ControlledUpgradeable, PausableUpgradeab
         return 1;
     }
 
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.0";
+    }
+
     /// @notice IERC165 supports an interfaceId
     /// @param interfaceId The interfaceId to check
     /// @return true if the interfaceId is supported

--- a/src/deployment/ControlledUpgradeable.sol
+++ b/src/deployment/ControlledUpgradeable.sol
@@ -21,4 +21,6 @@ abstract contract ControlledUpgradeable is UUPSUpgradeable, AccessControlDefault
     }
 
     function version() public virtual returns (uint8);
+
+    function publicVersion() public virtual returns (string memory) {}
 }

--- a/src/deployment/ControlledUpgradeable.sol
+++ b/src/deployment/ControlledUpgradeable.sol
@@ -22,5 +22,5 @@ abstract contract ControlledUpgradeable is UUPSUpgradeable, AccessControlDefault
 
     function version() public virtual returns (uint8);
 
-    function publicVersion() public virtual returns (string memory) {}
+    function publicVersion() public virtual returns (string memory);
 }

--- a/test/USDPlus.t.sol
+++ b/test/USDPlus.t.sol
@@ -53,6 +53,7 @@ contract UsdPlusTest is Test {
 
     function test_deployment() public {
         assertEq(usdplus.version(), 1);
+        assertEq(usdplus.publicVersion(), "1.0.0");
     }
 
     function test_treasury(address treasury) public {

--- a/test/UsdPlusMinter.t.sol
+++ b/test/UsdPlusMinter.t.sol
@@ -80,6 +80,7 @@ contract UsdPlusMinterTest is Test {
 
     function test_version() public {
         assertEq(minter.version(), 1);
+        assertEq(minter.publicVersion(), "1.0.0");
     }
 
     function test_setPaymentRecipient(address recipient) public {

--- a/test/UsdPlusRedeemer.t.sol
+++ b/test/UsdPlusRedeemer.t.sol
@@ -91,6 +91,7 @@ contract UsdPlusRedeemerTest is Test {
         assertEq(redeemer.usdplus(), address(usdplus));
         assertEq(redeemer.nextTicket(), 0);
         assertEq(redeemer.version(), 1);
+        assertEq(redeemer.publicVersion(), "1.0.0");
     }
 
     function test_setPaymentTokenOracle(IERC20 token, address oracle) public {

--- a/test/WrappedUSDPlus.t.sol
+++ b/test/WrappedUSDPlus.t.sol
@@ -68,6 +68,7 @@ contract WrappedUsdPlusTest is Test {
     function test_deploymentConfig() public {
         assertEq(wrappedUsdplus.decimals(), 6);
         assertEq(wrappedUsdplus.version(), 1);
+        assertEq(wrappedUsdplus.publicVersion(), "1.0.0");
     }
 
     function test_transferReverts(address to, uint104 amount) public {

--- a/test/bridge/CCIPWaypoint.t.sol
+++ b/test/bridge/CCIPWaypoint.t.sol
@@ -91,6 +91,7 @@ contract CCIPWaypointTest is Test {
     function test_initialization() public {
         assertEq(address(waypoint.getRouter()), address(router));
         assertEq(waypoint.version(), 1);
+        assertEq(waypoint.publicVersion(), "1.0.0");
     }
 
     function test_setRouterZeroReverts() public {

--- a/test/deployment/ControlledUpgrade.t.sol
+++ b/test/deployment/ControlledUpgrade.t.sol
@@ -73,6 +73,7 @@ contract ControlledUpgradeableTest is Test {
             address(controlledV2Impl), abi.encodeWithSelector(MockControlledV2.reinitialize.selector, 0)
         );
         assertEq(MockControlled(address(upgradeableContract)).version(), 3);
+        assertEq(MockControlled(address(upgradeableContract)).publicVersion(), "1.0.2");
         vm.stopPrank();
     }
 
@@ -90,6 +91,7 @@ contract ControlledUpgradeableTest is Test {
         );
         assertEq(MockOwnableControlled(address(ownable)).hasRole(ownableControlledImpl.UPGRADER_ROLE(), UPGRADER), true);
         assertEq(MockOwnableControlled(address(ownable)).version(), 2);
+        assertEq(MockOwnableControlled(address(ownable)).publicVersion(), "1.0.1");
 
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/utils/mocks/MockControlled.sol
+++ b/test/utils/mocks/MockControlled.sol
@@ -20,4 +20,8 @@ contract MockControlled is ControlledUpgradeable {
     function version() public pure override returns (uint8) {
         return 2;
     }
+
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.1";
+    }
 }

--- a/test/utils/mocks/MockControlledV2.sol
+++ b/test/utils/mocks/MockControlledV2.sol
@@ -22,4 +22,8 @@ contract MockControlledV2 is ControlledUpgradeable {
     function version() public pure override returns (uint8) {
         return 3;
     }
+
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.2";
+    }
 }

--- a/test/utils/mocks/MockOwnableControlled.sol
+++ b/test/utils/mocks/MockOwnableControlled.sol
@@ -22,4 +22,8 @@ contract MockOwnableControlled is ControlledUpgradeable {
     function version() public pure override returns (uint8) {
         return 2;
     }
+
+    function publicVersion() public pure override returns (string memory) {
+        return "1.0.1";
+    }
 }


### PR DESCRIPTION
https://dinari.atlassian.net/jira/software/projects/DSHARE/boards/2?assignee=712020%3Aa20e54a0-5e4c-4203-9d5b-a3911c614d59&selectedIssue=DSHARE-1067

A new method called publicVersion should be implemented which will return a string corresponding to the release version (e.x 1.0.0, 1.0.1, etc)