### PR TITLE
[DSHARE-1078] Add proxy role to redeemer contract

### DIFF
--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -16,7 +16,6 @@ import {SelfPermit} from "./SelfPermit.sol";
 
 /// @notice manages requests for USD+ burning
 /// @author Dinari (https://github.com/dinaricrypto/usdplus-contracts/blob/main/src/Redeemer.sol)
-// TODO: remove owner from redeem request calls
 contract UsdPlusRedeemer is
     IUsdPlusRedeemer,
     UUPSUpgradeable,

--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -194,6 +194,7 @@ contract UsdPlusRedeemer is
 
         emit RequestCreated(ticket, receiver, paymentToken, paymentTokenAmount, usdplusAmount);
 
+        // slither-disable-next-line arbitrary-send-erc20
         IERC20($._usdplus).safeTransferFrom(owner, address(this), usdplusAmount);
 
         UsdPlus($._usdplus).burn(address(this), usdplusAmount);

--- a/src/UsdPlusRedeemer.sol
+++ b/src/UsdPlusRedeemer.sol
@@ -31,6 +31,7 @@ contract UsdPlusRedeemer is
     error ZeroAmount();
 
     bytes32 public constant FULFILLER_ROLE = keccak256("FULFILLER_ROLE");
+    bytes32 public constant PROXY_ROLE = keccak256("PROXY_ROLE");
 
     /// ------------------ Storage ------------------
 
@@ -173,7 +174,7 @@ contract UsdPlusRedeemer is
         address receiver,
         address owner
     ) internal returns (uint256 ticket) {
-        if (msg.sender != owner) {
+        if (msg.sender != owner && !hasRole(PROXY_ROLE, msg.sender)) {
             revert UnauthorizedRedeemer();
         }
 
@@ -184,7 +185,7 @@ contract UsdPlusRedeemer is
         }
 
         $._requests[ticket] = Request({
-            owner: msg.sender,
+            owner: owner,
             receiver: receiver,
             paymentToken: paymentToken,
             paymentTokenAmount: paymentTokenAmount,
@@ -193,7 +194,7 @@ contract UsdPlusRedeemer is
 
         emit RequestCreated(ticket, receiver, paymentToken, paymentTokenAmount, usdplusAmount);
 
-        IERC20($._usdplus).safeTransferFrom(msg.sender, address(this), usdplusAmount);
+        IERC20($._usdplus).safeTransferFrom(owner, address(this), usdplusAmount);
 
         UsdPlus($._usdplus).burn(address(this), usdplusAmount);
     }

--- a/test/UsdPlusRedeemer.t.sol
+++ b/test/UsdPlusRedeemer.t.sol
@@ -262,10 +262,19 @@ contract UsdPlusRedeemerTest is Test {
         vm.prank(USER);
         usdplus.approve(address(redeemer), amount);
 
+        // set limit
+        vm.prank(ADMIN);
+        usdplus.setIssuerLimits(address(redeemer), 0, type(uint256).max);
+
         // Try to redeem on behalf of USER without authorization
         vm.prank(ATTACKER);
         vm.expectRevert(IUsdPlusRedeemer.UnauthorizedRedeemer.selector);
         redeemer.requestRedeem(paymentToken, amount, USER, USER);
+
+        vm.startPrank(ADMIN);
+        redeemer.grantRole(redeemer.PROXY_ROLE(), ADMIN);
+        redeemer.requestRedeem(paymentToken, amount, USER, USER);
+        vm.stopPrank();
     }
 
     function test_permitRequestRedeem(uint256 amount) public {


### PR DESCRIPTION
[https://dinari.atlassian.net/browse/DSHARE-1078](https://dinari.atlassian.net/browse/DSHARE-1078)

Problem: The Production Enterprise API Withdrawal functionality is not working due to changes made to the USD+ Redeemer contract 2 months ago that removed the ability for proxy USD+ redeem requests.

Impact: Customers have not been using the withdrawals endpoint for the past 2 months.

Causes: The issue was caused by a change in the USD+ Redeemer contract that now requires the caller of the `requestRedeem` function to be the owner of the USD+.