### PR TITLE
[DSHARE-1235] reverse contract name mapping in release deployment script

### DIFF
--- a/script/Release.s.sol
+++ b/script/Release.s.sol
@@ -44,8 +44,8 @@ contract Release is Script {
         // Get params
         address proxyAddress;
         string memory deployedVersion;
-        string memory contractName = vm.envString("CONTRACT"); // Now expects PascalCase (e.g., "TransferRestrictor")
-        string memory configName = _getConfigName(contractName); // Convert to underscore format for config
+        string memory contractName = vm.envString("CONTRACT");
+        string memory configName = _getConfigName(contractName);
         string memory currentVersion = vm.envString("VERSION");
         string memory environment = vm.envString("ENVIRONMENT");
         string memory configPath =

--- a/script/Release.s.sol
+++ b/script/Release.s.sol
@@ -127,7 +127,6 @@ contract Release is Script {
         revert(string.concat("Unsupported contract: ", contractName));
     }
 
-    // Rest of the initialization functions remain the same
     function _getInitDataForUsdPlus(bytes memory params, bool isUpgrade) private pure returns (bytes memory) {
         if (isUpgrade) {
             address upgrader = abi.decode(params, (address));

--- a/script/Release.s.sol
+++ b/script/Release.s.sol
@@ -6,54 +6,40 @@ import {stdJson} from "forge-std/StdJson.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ControlledUpgradeable} from "../src/deployment/ControlledUpgradeable.sol";
 import {console2} from "forge-std/console2.sol";
-
 import {VmSafe} from "forge-std/Vm.sol";
 
 interface IVersioned {
-    // The version function that must be implemented by the inheriting contract
     function publicVersion() external view returns (string memory);
 }
 
 contract Release is Script {
     using stdJson for string;
 
-    /**
-     * @notice Main deployment script for handling new deployments and upgrades
-     * @dev Prerequisites:
-     *      1. Environment Variables:
-     *         - PRIVATE_KEY: (for signing transactions)
-     *         - RPC_URL: (for connecting to the network)
-     *         - VERSION: Current version being deployed
-     *         - ENVIRONMENT: Target environment (e.g., production, staging)
-     *         - DEPLOYED_VERSION: (Optional) Previous version for upgrades
-     *
-     *      2. Required Files:
-     *         - release_config/{environment}/{chainId}.json: Contract initialization params
-     *
-     * @dev Workflow:
-     *      1. Loads configuration and parameters from environment and JSON files
-     *      2. Checks for previous deployment address
-     *      3. If no previous deployment (address(0)):
-     *         - Deploys new implementation and proxy
-     *      4. If previous deployment exists:
-     *         - Checks version difference
-     *         - Upgrades if version changed or previous version not available
-     *      5. Writes deployment result to artifact/{environment}/{chainId}.{contractName}.json
-     * @dev Run:
-     *      ./script/release_sh
-     */
+    // Mapping of PascalCase contract names to their underscore versions
+    function _getConfigName(string memory contractName) internal pure returns (string memory) {
+        bytes32 inputHash = keccak256(bytes(contractName));
+
+        if (inputHash == keccak256(bytes("TransferRestrictor"))) return "transfer_restrictor";
+        if (inputHash == keccak256(bytes("UsdPlusMinter"))) return "usdplus_minter";
+        if (inputHash == keccak256(bytes("CCIPWaypoint"))) return "ccip_waypoint";
+        if (inputHash == keccak256(bytes("UsdPlusRedeemer"))) return "usdplus_redeemer";
+        if (inputHash == keccak256(bytes("UsdPlus"))) return "usdplus";
+
+        revert(string.concat("Unknown contract name: ", contractName));
+    }
+
     function run() external {
         // Get params
         address proxyAddress;
         string memory deployedVersion;
-        string memory contractName = vm.envString("CONTRACT");
-        string memory normalizeContractName = _normalizeContractName(contractName);
+        string memory contractName = vm.envString("CONTRACT"); // Now expects PascalCase (e.g., "TransferRestrictor")
+        string memory configName = _getConfigName(contractName); // Convert to underscore format for config
         string memory currentVersion = vm.envString("VERSION");
         string memory environment = vm.envString("ENVIRONMENT");
         string memory configPath =
             string.concat("release_config/", environment, "/", vm.toString(block.chainid), ".json");
         string memory configJson = vm.readFile(configPath);
-        bytes memory initParams = configJson.parseRaw(string.concat(".", normalizeContractName));
+        bytes memory initParams = configJson.parseRaw(string.concat(".", configName));
 
         try vm.envString("DEPLOYED_VERSION") returns (string memory v) {
             deployedVersion = v;
@@ -64,36 +50,31 @@ contract Release is Script {
         vm.startBroadcast();
 
         address previousDeploymentAddress =
-            _getPreviousDeploymentAddress(contractName, deployedVersion, environment, block.chainid);
+            _getPreviousDeploymentAddress(configName, deployedVersion, environment, block.chainid);
 
         if (previousDeploymentAddress == address(0)) {
-            console2.log("No previous deployment found for %s", normalizeContractName);
-            // Deploy new contract
-            proxyAddress =
-                _deployContract(normalizeContractName, _getInitData(normalizeContractName, initParams, false));
+            console2.log("No previous deployment found for %s", contractName);
+            proxyAddress = _deployContract(contractName, _getInitData(contractName, initParams, false));
         } else {
             string memory previousVersion;
-            // Get the previous version of the contract
             try IVersioned(previousDeploymentAddress).publicVersion() returns (string memory v) {
                 previousVersion = v;
             } catch {}
+
             if (
                 keccak256(bytes(previousVersion)) != keccak256(bytes(currentVersion))
                     || bytes(previousVersion).length == 0
             ) {
-                // Upgrade existing contract
                 proxyAddress = _upgradeContract(
-                    normalizeContractName,
-                    previousDeploymentAddress,
-                    _getInitData(normalizeContractName, initParams, true)
+                    contractName, previousDeploymentAddress, _getInitData(contractName, initParams, true)
                 );
             }
         }
 
         vm.stopBroadcast();
 
-        // Write result to chain-specific file
-        _writeDeployment(environment, block.chainid, contractName, proxyAddress);
+        // Write result using underscore format for file naming
+        _writeDeployment(environment, block.chainid, configName, proxyAddress);
     }
 
     function _getInitData(string memory contractName, bytes memory params, bool isUpgrade)
@@ -121,6 +102,7 @@ contract Release is Script {
         revert(string.concat("Unsupported contract: ", contractName));
     }
 
+    // Rest of the initialization functions remain the same
     function _getInitDataForUsdPlus(bytes memory params, bool isUpgrade) private pure returns (bytes memory) {
         if (isUpgrade) {
             address upgrader = abi.decode(params, (address));
@@ -139,7 +121,7 @@ contract Release is Script {
         pure
         returns (bytes memory)
     {
-        if (isUpgrade) return bytes("0x"); // No reinitialization needed
+        if (isUpgrade) return bytes("0x");
 
         (address owner, address upgrader) = abi.decode(params, (address, address));
         return abi.encodeWithSignature("initialize(address,address)", owner, upgrader);
@@ -202,7 +184,6 @@ contract Release is Script {
         return proxyAddress;
     }
 
-    // Helper functions remain similar to previous implementation
     function _deployImplementation(string memory contractName) internal returns (address) {
         bytes memory creationCode = vm.getCode(string.concat(contractName, ".sol:", contractName));
         require(creationCode.length > 0, string.concat("Contract code not found: ", contractName));
@@ -216,14 +197,14 @@ contract Release is Script {
     }
 
     function _getPreviousDeploymentAddress(
-        string memory contractName,
+        string memory configName,
         string memory deployedVersion,
         string memory environment,
         uint256 chainId
     ) internal returns (address) {
         if (bytes(deployedVersion).length == 0) return address(0);
 
-        string memory deployedPath = string.concat("releases/", deployedVersion, "/", contractName, ".json");
+        string memory deployedPath = string.concat("releases/", deployedVersion, "/", configName, ".json");
         if (!vm.exists(deployedPath)) return address(0);
 
         try vm.parseJsonAddress(
@@ -238,10 +219,9 @@ contract Release is Script {
     function _writeDeployment(
         string memory environment,
         uint256 chainId,
-        string memory contractName,
+        string memory configName,
         address deployedAddress
     ) internal {
-        // Create temp directory structure
         string memory tempDir = "artifact";
         string memory tempEnvDir = string.concat(tempDir, "/", environment);
 
@@ -252,25 +232,12 @@ contract Release is Script {
             vm.createDir(tempEnvDir, true);
         }
 
-        // Create deployment file under artifact/environment/chainId.contractName.json
         string memory deploymentPath =
-            string.concat(tempDir, "/", environment, "/", vm.toString(chainId), ".", contractName, ".json");
+            string.concat(tempDir, "/", environment, "/", vm.toString(chainId), ".", configName, ".json");
 
         string memory json = vm.serializeAddress("{}", "address", deployedAddress);
         vm.writeFile(deploymentPath, json);
 
         console2.log("Deployment written to:", deploymentPath);
-    }
-
-    function _normalizeContractName(string memory input) private pure returns (string memory) {
-        bytes32 inputHash = keccak256(bytes(input));
-
-        if (inputHash == keccak256(bytes("transfer_restrictor"))) return "TransferRestrictor";
-        if (inputHash == keccak256(bytes("usdplus_minter"))) return "UsdPlusMinter";
-        if (inputHash == keccak256(bytes("ccip_waypoint"))) return "CCIPWaypoint";
-        if (inputHash == keccak256(bytes("usdplus_redeemer"))) return "UsdPlusRedeemer";
-        if (inputHash == keccak256(bytes("usdplus"))) return "UsdPlus";
-
-        revert(string.concat("Unknown contract name: ", input));
     }
 }

--- a/script/release.sh
+++ b/script/release.sh
@@ -12,7 +12,7 @@
 
 export VERSION="1.0.0" # Version of current deployment
 
-CONTRACTS=("usdplus" "transfer_restrictor" "usdplus_minter" "usdplus_redeemer" "ccip_waypoint")
+CONTRACTS=("UsdPlus" "TransferRestrictor" "UsdPlusMinter" "UsdPlusRedeemer" "CCIPWaypoint")
 
 for i in "${CONTRACTS[@]}"; do
    echo "Deploying $i"


### PR DESCRIPTION
This [PR](https://dinari.atlassian.net/browse/DSHARE-1235) Reverse the mapping flow to accept PascalCase contract names (matching our .sol files) and handle the conversion to underscore format internally for config files and artifacts.