### PR TITLE
[DSHARE-1243] Fix PascalCase initParams

### DIFF
--- a/script/Release.s.sol
+++ b/script/Release.s.sol
@@ -51,7 +51,7 @@ contract Release is Script {
         string memory configPath =
             string.concat("release_config/", environment, "/", vm.toString(block.chainid), ".json");
         string memory configJson = vm.readFile(configPath);
-        bytes memory initParams = configJson.parseRaw(string.concat(".", configName));
+        bytes memory initParams = configJson.parseRaw(string.concat(".", contractName));
 
         try vm.envString("DEPLOYED_VERSION") returns (string memory v) {
             deployedVersion = v;


### PR DESCRIPTION
[https://dinari.atlassian.net/browse/DSHARE-1243](https://dinari.atlassian.net/browse/DSHARE-1243)

issue
```
[21098] Release::run()
    ├─ [0] VM::envString("CONTRACT") [staticcall]
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::envString("VERSION") [staticcall]
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::envString("ENVIRONMENT") [staticcall]
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::toString(11155111 [1.115e7]) [staticcall]
    │   └─ ← [Return] "11155111"
    ├─ [0] VM::readFile("release_config/staging/11155111.json") [staticcall]
    │   └─ ← [Return] <file>
    ├─ [0] VM::parseJson("<JSON file>", ".usdplus") [staticcall]
    │   └─ ← [Return] <encoded JSON value>
    ├─ [0] VM::envString("DEPLOYED_VERSION") [staticcall]
    │   └─ ← [Revert] vm.envString: environment variable "DEPLOYED_VERSION" not found
    ├─ [0] VM::startBroadcast()
    │   └─ ← [Return]
    ├─ [0] console::log("No previous deployment found for %s", "UsdPlus") [staticcall]
    │   └─ ← [Stop]
    └─ ← [Revert] EvmError: Revert
```

fix
```
[⠊] Compiling...
[⠊] Compiling 1 files with Solc 0.8.25
[⠒] Solc 0.8.25 finished in 1.95s
Compiler run successful!
Script ran successfully.

== Logs ==
  No previous deployment found for UsdPlus
  Deploying UsdPlus
  Deployed UsdPlus at 0xe9CCdFa2862831AbD822afD7e8063814Ed3078fa
  Deployment written to: artifact/staging/11155111.usdplus.json

## Setting up 1 EVM.
```