### PR TITLE
[DSHARE-1531] Fix upgrade from Ownable -> AccessControl

### DIFF
--- a/script/Release.s.sol
+++ b/script/Release.s.sol
@@ -7,7 +7,6 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 import {ControlledUpgradeable} from "../src/deployment/ControlledUpgradeable.sol";
 import {console2} from "forge-std/console2.sol";
 import {VmSafe} from "forge-std/Vm.sol";
-import {UUPSUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import {WrappedUsdPlus} from "../src/WrappedUsdPlus.sol";
 import {CCIPWaypoint} from "../src/bridge/CCIPWaypoint.sol";
@@ -74,7 +73,7 @@ contract Release is Script {
         bytes memory initData = _getInitData(configJson, contractName, false);
         bytes memory upgradeData = _getInitData(configJson, contractName, true);
 
-        vm.startPrank(address(0x269e944aD9140fc6e21794e8eA71cE1AfBfe38c8));
+        vm.startBroadcast();
         if (previousDeploymentAddress == address(0)) {
             console2.log("Deploying contract");
             proxyAddress = _deployContract(contractName, initData);
@@ -85,7 +84,7 @@ contract Release is Script {
                 proxyAddress = _upgradeContract(contractName, previousDeploymentAddress, upgradeData);
             }
         }
-        vm.stopPrank();
+        vm.stopBroadcast();
 
         // Write result using underscore format for file naming
         if (proxyAddress != address(0)) {


### PR DESCRIPTION
### Ticket

[Please link any clickup tickets, docs or other relevant context.](https://dinari.atlassian.net/jira/software/projects/DSHARE/boards/2?assignee=712020%3Aa20e54a0-5e4c-4203-9d5b-a3911c614d59&selectedIssue=DSHARE-1531)


### Description
```
    │   │   ├─ [589] WrappedUsdPlus::proxiableUUID() [staticcall]
    │   │   │   └─ ← [Return] 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
    │   │   ├─ emit Upgraded(implementation: WrappedUsdPlus: [0x0aFE5A2821EC24174412263a72E43947Fe888F0e])
    │   │   ├─ [1290] WrappedUsdPlus::0174a1cc(000000000000000000000000269e944ad9140fc6e21794e8ea71ce1afbfe38c80000000000000000000000006873a19fbbea962728432bf968c62902c0533530) [delegatecall]
    │   │   │   └─ ← [Revert] EvmError: Revert
    │   │   └─ ← [Revert] FailedInnerCall()
    │   └─ ← [Revert] FailedInnerCall()
    └─ ← [Revert] FailedInnerCall()
```

InnerCall due to wrong signatures, switch to encodeSelector instead



### Tests

What tests scenarios did you perform? Provide relevant screenshot/recordings here.
